### PR TITLE
Update events.lua

### DIFF
--- a/game/dota_addons/addon_template_butt/scripts/vscripts/internal/events.lua
+++ b/game/dota_addons/addon_template_butt/scripts/vscripts/internal/events.lua
@@ -16,12 +16,18 @@ ListenToGameEvent("game_rules_state_change", function()
 		GameRules:GetGameModeEntity():SetCustomHeroMaxLevel(BUTTINGS.MAX_LEVEL)
 
 		if ("AR"==BUTTINGS.GAME_MODE) then
-			local time = (BUTTINGS.HERO_BANNING) and 16 or 0
+			local time = (BUTTINGS.HERO_BANNING)*16 or 0
 			GameRules:GetGameModeEntity():SetThink( function()
 				for p,player in pairs(PlayerList:GetValidTeamPlayers()) do
 					player:MakeRandomHeroSelection()
 				end
 			end, time)
+		end
+
+		if (BUTTINGS.HERO_BANNING==0) then
+			GameRules:GetGameModeEntity():SetDraftingBanningTimeOverride( 0 )
+		else
+			GameRules:GetGameModeEntity():SetDraftingBanningTimeOverride( 16 )
 		end
 	-- elseif (GameRules:State_Get()>=DOTA_GAMERULES_STATE_PRE_GAME) then
 		-- GameRules:GetGameModeEntity():SetThink( function(asd)


### PR DESCRIPTION
1. Idk why, but in Dota logic, 0 and 16 gives 16, 1 and 16 - 16. Therefore delay before random pick in AR always was 16s, even when banning was not selected. Simple 0*16 and 1*16 always will give wanted result.
2. Made banning slightly longer(12s->16s), to match random picking time. 16 is a good number.
3. Disabled banning phase time, if banning was not selected. Basically stole from Moddota discord, specifically from message with this commit: https://github.com/dota2unofficial/overthrow2/commit/258765f5f53d695fcf98eba382339f786334f774

Worked perfectly fine when tested both in blank and finished templates