### PR TITLE
Respawn time fix, and potential max level <30 fix.

### DIFF
--- a/game/dota_addons/addon_template_butt/scripts/vscripts/internal/events.lua
+++ b/game/dota_addons/addon_template_butt/scripts/vscripts/internal/events.lua
@@ -11,8 +11,8 @@ ListenToGameEvent("game_rules_state_change", function()
 
 		
 		GameRules:GetGameModeEntity():SetCustomXPRequiredToReachNextLevel( BUTTINGS.ALTERNATIVE_XP_TABLE() )
-		GameRules:GetGameModeEntity():SetUseCustomHeroLevels(BUTTINGS.MAX_LEVEL~=25)
-		GameRules:SetUseCustomHeroXPValues(BUTTINGS.MAX_LEVEL~=25)
+		GameRules:GetGameModeEntity():SetUseCustomHeroLevels(true)
+		GameRules:SetUseCustomHeroXPValues(true)
 		GameRules:GetGameModeEntity():SetCustomHeroMaxLevel(BUTTINGS.MAX_LEVEL)
 
 		if ("AR"==BUTTINGS.GAME_MODE) then

--- a/game/dota_addons/addon_template_butt/scripts/vscripts/internal/events.lua
+++ b/game/dota_addons/addon_template_butt/scripts/vscripts/internal/events.lua
@@ -80,9 +80,9 @@ ListenToGameEvent("entity_killed", function(keys)
 	if killedUnit:IsRealHero() and not killedUnit:IsTempestDouble() and not killedUnit:IsReincarnating() then
 
 		-- fix respawn lvl>25
-		if (killedUnit:GetLevel()>25) then
-			print(killedUnit,killedUnit:GetName(),4*killedUnit:GetLevel())
-			killedUnit:SetTimeUntilRespawn(4*killedUnit:GetLevel())
+		if (killedUnit:GetLevel()>1) then
+			print(killedUnit,killedUnit:GetName(),4*killedUnit:GetLevel() * BUTTINGS.RESPAWN_TIME_PERCENTAGE * 0.01)
+			killedUnit:SetTimeUntilRespawn(4 * killedUnit:GetLevel() * BUTTINGS.RESPAWN_TIME_PERCENTAGE * 0.01)
 		end
 
 		-- tombstone


### PR DESCRIPTION
Respawn time fix, and potential max level <30 fix.
Should work even if xp table is bigger than max lvl.

Also, random note, high max level overflows and causes weird things to happen (leveling up levels to max, respawn time isn't insanely high and maybe other things. Not related to the changes.